### PR TITLE
Update SHA-256 of the APK in manifest

### DIFF
--- a/public/pay/manifest.json
+++ b/public/pay/manifest.json
@@ -17,7 +17,7 @@
       "min_version": "1",
       "fingerprints": [{
           "type": "sha256_cert",
-          "value": "92:5A:39:05:C5:B9:EA:BC:71:48:5F:F2:05:0A:1E:57:5F:23:40:E9:E3:87:14:EC:6D:A2:04:21:E0:FD:3B:D1"
+          "value": "78:58:31:7E:0A:CE:53:4E:9B:47:52:DE:A7:D3:E9:B0:22:2D:04:D1:61:64:DC:8A:2D:68:1F:FE:F3:3A:B1:1B"
       }]
   }]
 }


### PR DESCRIPTION
Although we've updated the APK for the download link, we haven't updated the SHA-256 of the APK in manifest. In order for the payment method manifest to verify the app, we should update the SHA-256.