### PR TITLE
Test out serving the payment manifest with a custom mime type

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,15 @@ app.use(function(req, res, next) {
     });
     return next();
 });
+
+// Serve the payment-manifest.json file with its own mime type.
+app.use(function(req, res, next) {
+  if (req.path.endsWith('payment-manifest.json')) {
+    res.set('Content-Type', 'application/x-payment-manifest');
+  }
+  return next();
+});
+
 // We are mostly a static website.
 app.use(express.static('public'));
 


### PR DESCRIPTION
Hi @agektmr,

We (+ @stephenmcgruer) are fairly certain that Chrome is permissive enough to accept any mime type of the Payment Method Manifest, but we'd like to double-check this hypothesis. Would it be possible to  land this patch (possibly temporarily) where 'payment-manifest.json' is served with the new custom 'application/x-payment-manifest' mime type? 

Thank you.

Cheers,
Rouslan